### PR TITLE
Add integration with `kratos-endpoint-info`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,9 +10,6 @@ options:
       Acceptable values are: "info", "debug", "warning", "error" and "critical"
     default: "info"
     type: string
-  kratos_url:
-    description: Kratos API URL. In the final version the operator uses the interface relation to get Kratos API URL. Config value is a fallback.
-    type: string
   hydra_url:
     description: Hydra API URL. In the final version the operator uses the interface relation to get Hydra API URL. Config value is a fallback.
     type: string

--- a/lib/charms/kratos/v0/kratos_endpoints.py
+++ b/lib/charms/kratos/v0/kratos_endpoints.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Interface library for sharing kratos endpoints.
+This library provides a Python API for both requesting and providing public and admin endpoints.
+## Getting Started
+To get started using the library, you need to fetch the library using `charmcraft`.
+```shell
+cd some-charm
+charmcraft fetch-lib charms.kratos.v0.kratos_endpoints
+```
+To use the library from the requirer side:
+In the `metadata.yaml` of the charm, add the following:
+```yaml
+requires:
+  kratos-endpoint-info:
+    interface: kratos_endpoints
+    limit: 1
+```
+Then, to initialise the library:
+```python
+from charms.kratos.v0.kratos_endpoints import (
+    KratosEndpointsRelationError,
+    KratosEndpointsRequirer,
+)
+Class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        self.kratos_endpoints_relation = KratosEndpointsRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+    def some_event_function():
+        # fetch the relation info
+        try:
+            kratos_data = self.kratos_endpoints_relation.get_kratos_endpoints()
+        except KratosEndpointsRelationError as error:
+            ...
+```
+"""
+
+import logging
+from typing import Dict, Optional
+
+from ops.charm import CharmBase, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.model import Application
+
+# The unique Charmhub library identifier, never change it
+LIBID = "5868b36df1c04c90b33f5e5557327162"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "kratos-endpoint-info"
+INTERFACE_NAME = "kratos_endpoints"
+logger = logging.getLogger(__name__)
+
+
+class KratosEndpointsRelationReadyEvent(EventBase):
+    """Event to notify the charm that the relation is ready."""
+
+
+class KratosEndpointsProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `KratosEndpointsProvider`."""
+
+    ready = EventSource(KratosEndpointsRelationReadyEvent)
+
+
+class KratosEndpointsProvider(Object):
+    """Provider side of the kratos-endpoint-info relation."""
+
+    on = KratosEndpointsProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_created, self._on_provider_endpoint_relation_created
+        )
+
+    def _on_provider_endpoint_relation_created(self, event: RelationCreatedEvent) -> None:
+        self.on.ready.emit()
+
+    def send_endpoint_relation_data(self, admin_endpoint: str, public_endpoint: str) -> None:
+        """Updates relation with endpoints info."""
+        if not self._charm.unit.is_leader():
+            return
+
+        relations = self.model.relations[self._relation_name]
+        for relation in relations:
+            relation.data[self._charm.app].update(
+                {
+                    "admin_endpoint": admin_endpoint,
+                    "public_endpoint": public_endpoint,
+                }
+            )
+
+
+class KratosEndpointsRelationError(Exception):
+    """Base class for the relation exceptions."""
+
+    pass
+
+
+class KratosEndpointsRelationMissingError(KratosEndpointsRelationError):
+    """Raised when the relation is missing."""
+
+    def __init__(self) -> None:
+        self.message = "Missing kratos-endpoint-info relation with kratos"
+        super().__init__(self.message)
+
+
+class KratosEndpointsRelationDataMissingError(KratosEndpointsRelationError):
+    """Raised when information is missing from the relation."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+
+class KratosEndpointsRequirer(Object):
+    """Requirer side of the kratos-endpoint-info relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def get_kratos_endpoints(self) -> Optional[Dict]:
+        """Get the kratos endpoints."""
+        if not self.model.unit.is_leader():
+            return None
+        endpoints = self.model.relations[self.relation_name]
+        if len(endpoints) == 0:
+            raise KratosEndpointsRelationMissingError()
+
+        remote_app = [
+            app
+            for app in endpoints[0].data.keys()
+            if isinstance(app, Application) and not app._is_our_app
+        ][0]
+
+        data = endpoints[0].data[remote_app]
+
+        if "public_endpoint" not in data:
+            raise KratosEndpointsRelationDataMissingError(
+                "Missing public endpoint in kratos-endpoint-info relation data"
+            )
+
+        return {
+            "admin_endpoint": data["admin_endpoint"],
+            "public_endpoint": data["public_endpoint"],
+        }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,3 +24,6 @@ resources:
 requires:
   ingress:
     interface: ingress
+  kratos-endpoint-info:
+    interface: kratos_endpoints
+    limit: 1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,6 @@ from ops.model import ActiveStatus, WaitingStatus
 CONTAINER_NAME = "login-ui"
 TEST_PORT = "8080"
 TEST_HYDRA_URL = "http://hydra:port"
-TEST_KRATOS_URL = "http://kratos:port"
 
 
 def setup_ingress_relation(harness) -> int:
@@ -26,6 +25,19 @@ def setup_ingress_relation(harness) -> int:
         {"ingress": json.dumps({"url": url})},
     )
     return relation_id
+
+
+def setup_kratos_relation(harness) -> None:
+    relation_id = harness.add_relation("kratos-endpoint-info", "kratos")
+    harness.add_relation_unit(relation_id, "kratos/0")
+    harness.update_relation_data(
+        relation_id,
+        "kratos",
+        {
+            "admin_endpoint": f"http://kratos-admin-url:80/{harness.model.name}-kratos",
+            "public_endpoint": f"http://kratos-public-url:80/{harness.model.name}-kratos",
+        },
+    )
 
 
 def test_not_leader(harness) -> None:
@@ -60,13 +72,13 @@ def test_install_can_not_connect(harness) -> None:
     assert harness.charm.unit.status == WaitingStatus("Waiting to connect to Login_UI container")
 
 
-def test_layer_updated(harness) -> None:
-    """Test Pebble Layers after updates."""
+def test_layer_updated_without_kratos_endpoint_info(harness) -> None:
+    """Test Pebble Layer after updates."""
     harness.set_leader(True)
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.login_ui_pebble_ready.emit(CONTAINER_NAME)
 
-    harness.update_config({"hydra_url": TEST_HYDRA_URL, "kratos_url": TEST_KRATOS_URL})
+    harness.update_config({"hydra_url": TEST_HYDRA_URL})
 
     expected_layer = {
         "summary": "login_ui layer",
@@ -79,7 +91,37 @@ def test_layer_updated(harness) -> None:
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": TEST_HYDRA_URL,
-                    "KRATOS_PUBLIC_URL": TEST_KRATOS_URL,
+                    "KRATOS_PUBLIC_URL": "",
+                    "PORT": TEST_PORT,
+                },
+            }
+        },
+    }
+
+    assert harness.charm._login_ui_layer.to_dict() == expected_layer
+
+
+def test_layer_updated_with_kratos_endpoint_info(harness) -> None:
+    """Test Pebble Layer when relation data is in place."""
+    harness.set_leader(True)
+    harness.set_can_connect(CONTAINER_NAME, True)
+    harness.charm.on.login_ui_pebble_ready.emit(CONTAINER_NAME)
+    setup_kratos_relation(harness)
+
+    harness.update_config({"hydra_url": TEST_HYDRA_URL})
+
+    expected_layer = {
+        "summary": "login_ui layer",
+        "description": "pebble config layer for identity platform login ui",
+        "services": {
+            CONTAINER_NAME: {
+                "override": "replace",
+                "summary": "identity platform login ui",
+                "command": "identity_platform_login_ui",
+                "startup": "enabled",
+                "environment": {
+                    "HYDRA_ADMIN_URL": TEST_HYDRA_URL,
+                    "KRATOS_PUBLIC_URL": f"http://kratos-public-url:80/{harness.model.name}-kratos",
                     "PORT": TEST_PORT,
                 },
             }


### PR DESCRIPTION
This PR adds integration with `kratos-endpoint-info` relation, substituting the `kratos_url` config option.

Integration tests will be included in `iam-bundle` tests.