### PR TITLE
IAM-311-Implement-Health-Checks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                     "override": "replace",
                     "summary": "identity platform login ui",
                     "command": "identity_platform_login_ui",
-                    "startup": "enabled",
+                    "startup": "disabled",
                     "environment": {
                         "HYDRA_ADMIN_URL": self._get_hydra_endpoint_info(),
                         "KRATOS_PUBLIC_URL": self._get_kratos_endpoint_info(),
@@ -146,6 +146,16 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                         "BASE_URL": self._domain_url,
                     },
                 }
+            },
+            "checks": {
+                "login-ui-ready": {
+                    "override": "replace",
+                    "http": {"url": f"http://localhost:{APPLICATION_PORT}/health/ready"},
+                },
+                "login-ui-alive": {
+                    "override": "replace",
+                    "http": {"url": f"http://localhost:{APPLICATION_PORT}/health/alive"},
+                },
             },
         }
         return Layer(pebble_layer)

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                     "override": "replace",
                     "summary": "identity platform login ui",
                     "command": "identity_platform_login_ui",
-                    "startup": "disabled",
+                    "startup": "enabled",
                     "environment": {
                         "HYDRA_ADMIN_URL": self._get_hydra_endpoint_info(),
                         "KRATOS_PUBLIC_URL": self._get_kratos_endpoint_info(),

--- a/src/charm.py
+++ b/src/charm.py
@@ -148,10 +148,6 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                 }
             },
             "checks": {
-                "login-ui-ready": {
-                    "override": "replace",
-                    "http": {"url": f"http://localhost:{APPLICATION_PORT}/health/ready"},
-                },
                 "login-ui-alive": {
                     "override": "replace",
                     "http": {"url": f"http://localhost:{APPLICATION_PORT}/health/alive"},

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -57,6 +57,7 @@ async def test_ingress_relation(ops_test: OpsTest):
     await ops_test.model.add_relation(f"{APP_NAME}:ingress", TRAEFIK_PUBLIC_APP)
 
     await ops_test.model.wait_for_idle(
+        apps=[TRAEFIK_PUBLIC_APP],
         status="active",
         raise_on_blocked=True,
         timeout=1000,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -113,10 +113,6 @@ def test_layer_updated_without_any_endpoint_info(harness: Harness) -> None:
             }
         },
         "checks": {
-            "login-ui-ready": {
-                "override": "replace",
-                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
-            },
             "login-ui-alive": {
                 "override": "replace",
                 "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
@@ -154,10 +150,6 @@ def test_layer_updated_with_kratos_endpoint_info(harness: Harness) -> None:
             }
         },
         "checks": {
-            "login-ui-ready": {
-                "override": "replace",
-                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
-            },
             "login-ui-alive": {
                 "override": "replace",
                 "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
@@ -195,10 +187,6 @@ def test_layer_updated_with_hydra_endpoint_info(harness: Harness) -> None:
             }
         },
         "checks": {
-            "login-ui-ready": {
-                "override": "replace",
-                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
-            },
             "login-ui-alive": {
                 "override": "replace",
                 "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
@@ -239,10 +227,6 @@ def test_layer_updated_with_endpoint_info(harness: Harness) -> None:
             }
         },
         "checks": {
-            "login-ui-ready": {
-                "override": "replace",
-                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
-            },
             "login-ui-alive": {
                 "override": "replace",
                 "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -103,7 +103,7 @@ def test_layer_updated_without_any_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "enabled",
+                "startup": "disabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
                     "KRATOS_PUBLIC_URL": "",
@@ -111,6 +111,16 @@ def test_layer_updated_without_any_endpoint_info(harness: Harness) -> None:
                     "BASE_URL": None,
                 },
             }
+        },
+        "checks": {
+            "login-ui-ready": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
+            },
+            "login-ui-alive": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
+            },
         },
     }
 
@@ -132,7 +142,7 @@ def test_layer_updated_with_kratos_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "enabled",
+                "startup": "disabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
                     "KRATOS_PUBLIC_URL": harness.get_relation_data(kratos_relation_id, "kratos")[
@@ -142,6 +152,16 @@ def test_layer_updated_with_kratos_endpoint_info(harness: Harness) -> None:
                     "BASE_URL": None,
                 },
             }
+        },
+        "checks": {
+            "login-ui-ready": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
+            },
+            "login-ui-alive": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
+            },
         },
     }
 
@@ -163,7 +183,7 @@ def test_layer_updated_with_hydra_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "enabled",
+                "startup": "disabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
                         "admin_endpoint"
@@ -173,6 +193,16 @@ def test_layer_updated_with_hydra_endpoint_info(harness: Harness) -> None:
                     "BASE_URL": None,
                 },
             }
+        },
+        "checks": {
+            "login-ui-ready": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
+            },
+            "login-ui-alive": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
+            },
         },
     }
 
@@ -195,7 +225,7 @@ def test_layer_updated_with_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "enabled",
+                "startup": "disabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
                         "admin_endpoint"
@@ -207,6 +237,16 @@ def test_layer_updated_with_endpoint_info(harness: Harness) -> None:
                     "BASE_URL": None,
                 },
             }
+        },
+        "checks": {
+            "login-ui-ready": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/ready"},
+            },
+            "login-ui-alive": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
+            },
         },
     }
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -266,6 +266,12 @@ def test_layer_updated_with_ingress_ready(harness: Harness) -> None:
                 },
             }
         },
+        "checks": {
+            "login-ui-alive": {
+                "override": "replace",
+                "http": {"url": f"http://localhost:{TEST_PORT}/health/alive"},
+            },
+        },
     }
 
     assert harness.charm._login_ui_layer.to_dict() == expected_layer

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -103,7 +103,7 @@ def test_layer_updated_without_any_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "disabled",
+                "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
                     "KRATOS_PUBLIC_URL": "",
@@ -142,7 +142,7 @@ def test_layer_updated_with_kratos_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "disabled",
+                "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
                     "KRATOS_PUBLIC_URL": harness.get_relation_data(kratos_relation_id, "kratos")[
@@ -183,7 +183,7 @@ def test_layer_updated_with_hydra_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "disabled",
+                "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
                         "admin_endpoint"
@@ -225,7 +225,7 @@ def test_layer_updated_with_endpoint_info(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "identity platform login ui",
                 "command": "identity_platform_login_ui",
-                "startup": "disabled",
+                "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
                         "admin_endpoint"


### PR DESCRIPTION
Pebble Health checks implemented for identity platform login ui operator.
Ready checks should fail without integrations with kratos and hydra. 
You can see failed ready checks with kubectl logs -n namespace login-ui-pod --container login-ui 