### PR TITLE
Update command to start the container

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -137,7 +137,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                 self._container_name: {
                     "override": "replace",
                     "summary": "identity platform login ui",
-                    "command": "identity_platform_login_ui",
+                    "command": "identity-platform-login-ui",
                     "startup": "enabled",
                     "environment": {
                         "HYDRA_ADMIN_URL": self._get_hydra_endpoint_info(),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -102,7 +102,7 @@ def test_layer_updated_without_any_endpoint_info(harness: Harness) -> None:
             CONTAINER_NAME: {
                 "override": "replace",
                 "summary": "identity platform login ui",
-                "command": "identity_platform_login_ui",
+                "command": "identity-platform-login-ui",
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
@@ -137,7 +137,7 @@ def test_layer_updated_with_kratos_endpoint_info(harness: Harness) -> None:
             CONTAINER_NAME: {
                 "override": "replace",
                 "summary": "identity platform login ui",
-                "command": "identity_platform_login_ui",
+                "command": "identity-platform-login-ui",
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": "",
@@ -174,7 +174,7 @@ def test_layer_updated_with_hydra_endpoint_info(harness: Harness) -> None:
             CONTAINER_NAME: {
                 "override": "replace",
                 "summary": "identity platform login ui",
-                "command": "identity_platform_login_ui",
+                "command": "identity-platform-login-ui",
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
@@ -212,7 +212,7 @@ def test_layer_updated_with_endpoint_info(harness: Harness) -> None:
             CONTAINER_NAME: {
                 "override": "replace",
                 "summary": "identity platform login ui",
-                "command": "identity_platform_login_ui",
+                "command": "identity-platform-login-ui",
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[
@@ -252,7 +252,7 @@ def test_layer_updated_with_ingress_ready(harness: Harness) -> None:
             CONTAINER_NAME: {
                 "override": "replace",
                 "summary": "identity platform login ui",
-                "command": "identity_platform_login_ui",
+                "command": "identity-platform-login-ui",
                 "startup": "enabled",
                 "environment": {
                     "HYDRA_ADMIN_URL": harness.get_relation_data(hydra_relation_id, "hydra")[


### PR DESCRIPTION
The login ui binary is now `/usr/bin/identity-platform-login-ui` rather than `/usr/bin/identity_platform_login_ui`.
This PR updates the command to start the container accordingly.