### PR TITLE
Install jsonschema from binary

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,3 +9,7 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - jsonschema


### PR DESCRIPTION
Fixes charmcraft packing, latest jsonschema version requires rust causing `pip install` to fail