### PR TITLE
Pin image version to stable

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,7 @@ resources:
     type: oci-image
     description: OCI image for login-ui
     # TODO @shipperizer i'd like to pin to a specific tag, but happy to move to stable if that's better, latest must go
-    upstream-source: ghcr.io/canonical/identity-platform-login-ui:e366a09b2d2556db1587e613a60ea551660da3ec
+    upstream-source: ghcr.io/canonical/identity-platform-login-ui:stable
 
 requires:
   ingress:


### PR DESCRIPTION
Update the image version, this will fix a bug which caused the first log in for a user to fail.