### PR TITLE
Added refresh events to MetricsEndpointProvider

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -99,11 +99,12 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                 }
             ],
             refresh_event=[
-                self.on.login_ui_pebble_ready,
+                self.on.update_status,
                 self.ingress.on.ready,
                 self.ingress.on.revoked,
+                self.on["ingress"].relation_changed,
+                self.on["ingress"].relation_departed,
             ],
-            external_url=self._domain_url or "",
         )
 
         self.loki_consumer = LogProxyConsumer(

--- a/src/charm.py
+++ b/src/charm.py
@@ -98,6 +98,12 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                     ],
                 }
             ],
+            refresh_event=[
+                self.on.login_ui_pebble_ready,
+                self.ingress.on.ready,
+                self.ingress.on.revoked,
+            ],
+            external_url=self._domain_url or "",
         )
 
         self.loki_consumer = LogProxyConsumer(


### PR DESCRIPTION
Added ingress events to the refresh_events input parameters to the MetricsEndpointProvider constructor. This causes the charm to reconfigure its integration with the Prometheus charm every time the events in refresh_events are called. The default for this value is the update_status.