### PR TITLE
ci: use canonical action to open PRs

### DIFF
--- a/.github/workflows/update_libs.yaml
+++ b/.github/workflows/update_libs.yaml
@@ -40,7 +40,7 @@ jobs:
         id: create-pull-request
         uses: canonical/create-pull-request@main
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           commit-message: Update charm libs
           branch-name: 'automated-update-charm-libs'
           title: (Automated) Update Charm Libs

--- a/.github/workflows/update_libs.yaml
+++ b/.github/workflows/update_libs.yaml
@@ -38,17 +38,12 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v5
+        uses: canonical/create-pull-request@main
         with:
-          title: '(Automated) Update Charm Libs'
-          body: 'Update charm libs'
-          commit-message: 'Update charm libs'
-          signoff: false
-          delete-branch: true
-          branch: 'automated-update-charm-libs'
-
-      - name: Print Created Pull Request
-        if: ${{ steps.create-pull-request.outputs.pull-request-number }}
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update charm libs
+          branch-name: 'automated-update-charm-libs'
+          title: (Automated) Update Charm Libs
+          body: Update charm libs
+          upsert: true
+          ignore-no-changes: true


### PR DESCRIPTION
Use https://github.com/canonical/create-pull-request rather than an external action to open pull requests for charm lib updates