### PR TITLE
IAM-460-Update login-ui relation

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -147,6 +147,14 @@ class LoginUIEndpointsRelationMissingError(LoginUIEndpointsRelationError):
         super().__init__(self.message)
 
 
+class LoginUIEndpointsRelationDataMissingError(LoginUIEndpointsRelationError):
+    """Raised when information is missing from the relation."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+
 class LoginUIEndpointsRequirer(Object):
     """Requirer side of the ui-endpoint-info relation."""
 
@@ -170,5 +178,10 @@ class LoginUIEndpointsRequirer(Object):
             raise LoginUIEndpointsRelationMissingError()
 
         ui_endpoint_relation_data = ui_endpoint_relation.data[ui_endpoint_relation.app]
+
+        if any(not ui_endpoint_relation_data.get(k := key) for key in RELATION_KEYS):
+            raise LoginUIEndpointsRelationDataMissingError(
+                f"Missing endpoint {k} in ui-endpoint-info relation data"
+            )
 
         return ui_endpoint_relation_data

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -63,7 +63,6 @@ RELATION_KEYS = [
     "error_url",
     "login_url",
     "oidc_error_url",
-    "default_url",
 ]
 
 
@@ -111,7 +110,6 @@ class LoginUIEndpointsProvider(Object):
                 "error_url": f"{endpoint}/ui/error",
                 "login_url": f"{endpoint}/ui/login",
                 "oidc_error_url": f"{endpoint}/ui/oidc_error",
-                "default_url": endpoint,
             }
         for relation in relations:
             relation.data[self._charm.app].update(endpoint_databag)

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -61,10 +61,8 @@ logger = logging.getLogger(__name__)
 RELATION_KEYS = [
     "consent_url",
     "error_url",
-    "index_url",
     "login_url",
     "oidc_error_url",
-    "registration_url",
     "default_url",
 ]
 
@@ -111,10 +109,8 @@ class LoginUIEndpointsProvider(Object):
             endpoint_databag = {
                 "consent_url": f"{endpoint}/ui/consent",
                 "error_url": f"{endpoint}/ui/error",
-                "index_url": f"{endpoint}/ui/index",
                 "login_url": f"{endpoint}/ui/login",
                 "oidc_error_url": f"{endpoint}/ui/oidc_error",
-                "registration_url": f"{endpoint}/ui/registration",
                 "default_url": endpoint,
             }
         for relation in relations:

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -147,14 +147,6 @@ class LoginUIEndpointsRelationMissingError(LoginUIEndpointsRelationError):
         super().__init__(self.message)
 
 
-class LoginUIEndpointsRelationDataMissingError(LoginUIEndpointsRelationError):
-    """Raised when information is missing from the relation."""
-
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(self.message)
-
-
 class LoginUIEndpointsRequirer(Object):
     """Requirer side of the ui-endpoint-info relation."""
 
@@ -178,10 +170,5 @@ class LoginUIEndpointsRequirer(Object):
             raise LoginUIEndpointsRelationMissingError()
 
         ui_endpoint_relation_data = ui_endpoint_relation.data[ui_endpoint_relation.app]
-
-        if any(not ui_endpoint_relation_data.get(k := key) for key in RELATION_KEYS):
-            raise LoginUIEndpointsRelationDataMissingError(
-                f"Missing endpoint {k} in ui-endpoint-info relation data"
-            )
 
         return ui_endpoint_relation_data


### PR DESCRIPTION
As part of IAM-460, I took out the unused pages from the login-ui backend. For this reason, the login-ui-relation relation was also updated to not include invalid links.