### PR TITLE
IAM-448-Add channel-base parameter to release-charm action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
       - name: Release charm to channel
+<<<<<<< HEAD
         uses: canonical/charming-actions/release-charm@631c2d944da2bd12430f1f3a954c8fffcf2385cd # 2.4.0
+=======
+        uses: canonical/charming-actions/release-charm@2.4.0
+>>>>>>> 72be877 (fix: update charming/action/release-charm to 2.4.0 in release action)
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,3 +28,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: '22.04'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
       - name: Release charm to channel
-<<<<<<< HEAD
         uses: canonical/charming-actions/release-charm@631c2d944da2bd12430f1f3a954c8fffcf2385cd # 2.4.0
-=======
-        uses: canonical/charming-actions/release-charm@2.4.0
->>>>>>> 72be877 (fix: update charming/action/release-charm to 2.4.0 in release action)
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
 Update charming/action/release-charm to 2.4.0, and add base-channel parameter to release-charm in release github action.