### PR TITLE
fix(loki-rule): improve error handling in json parsing

### DIFF
--- a/src/loki_alert_rules/login_ui_high_severity_log.rule
+++ b/src/loki_alert_rules/login_ui_high_severity_log.rule
@@ -2,7 +2,7 @@ groups:
 - name: LoginUIHighSeverityLog
   rules:
   - alert: HighFrequencyHighSeverityLog
-    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) > 100
+    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | __error__ != "JSONParserErr" | severity =~ `error|fatal|critical` [5m])) > 100
     labels:
       severity: error
     annotations:


### PR DESCRIPTION
# Description
This PR simply adds a LogQL `label filter` to avoid loki processing log entry that failed json parsing.