### PR TITLE
chore: replace black with ruff as the formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,15 +9,23 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+      - tomli
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-- repo: https://github.com/psf/black
-  rev: 24.4.0
-  hooks:
-  - id: black
+    - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.9.0
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ enhancements to this operator.
 ## Developing
 
 You can use the environments created by `tox` for development. It helps
-install `pre-commit` and `mypy` type checker.
+install `pre-commit`, `mypy` type checker, linting tools, and formatting tools.
 
 ```shell
 tox -e dev

--- a/fmt-requirements.txt
+++ b/fmt-requirements.txt
@@ -1,2 +1,2 @@
-black
 isort
+ruff

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,9 +1,3 @@
-black
-flake8==6.1.0
-flake8-docstrings
-flake8-copyright
-flake8-builtins
-pyproject-flake8
-pep8-naming
-isort
 codespell
+isort
+ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,29 +12,83 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
+# Linting and formatting tools configuration
+[tool.codespell]
+# https://github.com/codespell-project/codespell
+skip = ".git,.tox,build,lib,venv,.venv,.mypy_cache,icon.svg,__pycache__"
 
 [tool.isort]
+# Profiles: https://pycqa.github.io/isort/docs/configuration/profiles.html
 line_length = 99
 profile = "black"
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+# Default settings: https://docs.astral.sh/ruff/configuration/
+# Settings: https://docs.astral.sh/ruff/settings/
+line-length = 99
+include = [
+    "pyproject.toml",
+    "src/**/*.py",
+    "tests/**/*.py",
+    "lib/charms/identity_platform_login_ui_operator/**/*.py"
+]
+extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
+preview = true
+
+[tool.ruff.lint]
+# Rules: https://docs.astral.sh/ruff/rules/
+select = ["E", "W", "F", "C", "N", "D", "CPY"]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+    "E501",
+    "N818"
+]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.flake8-copyright]
+author = "Canonical Ltd."
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.mypy]
+pretty = true
+mypy_path = "./src:./lib/:./tests"
+# Exclude non-login-ui libraries
+exclude = 'lib/charms/((?!identity_platform_login_ui_operator/).)'
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "pytest.*", "pytest_operator.*", "urllib3.*", "jinja2.*", "lightkube.*", "pytest_mock.*"]
+ignore_missing_imports = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 # Learn more at: https://juju.is/docs/sdk
 
 """A Juju charm for Identity Platform Login UI."""
+
 import logging
 import re
 from typing import Optional

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Unit test configuration."""
+
 from unittest.mock import MagicMock
 
 import ops.testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 """Test functions for unit testing Identity Platform Login UI Operator."""
+
 import json
 from typing import Tuple
 
@@ -57,27 +58,23 @@ def setup_hydra_relation(harness: Harness) -> int:
     return relation_id
 
 
-def setup_loki_relation(harness: Harness) -> int:
+def setup_loki_relation(harness: Harness) -> None:
     relation_id = harness.add_relation("logging", "loki-k8s")
     harness.add_relation_unit(relation_id, "loki-k8s/0")
     databag = {
-        "promtail_binary_zip_url": json.dumps(
-            {
-                "amd64": {
-                    "filename": "promtail-static-amd64",
-                    "zipsha": "543e333b0184e14015a42c3c9e9e66d2464aaa66eca48b29e185a6a18f67ab6d",
-                    "binsha": "17e2e271e65f793a9fbe81eab887b941e9d680abe82d5a0602888c50f5e0cac9",
-                    "url": "https://github.com/canonical/loki-k8s-operator/releases/download/promtail-v2.5.0/promtail-static-amd64.gz",
-                }
+        "promtail_binary_zip_url": json.dumps({
+            "amd64": {
+                "filename": "promtail-static-amd64",
+                "zipsha": "543e333b0184e14015a42c3c9e9e66d2464aaa66eca48b29e185a6a18f67ab6d",
+                "binsha": "17e2e271e65f793a9fbe81eab887b941e9d680abe82d5a0602888c50f5e0cac9",
+                "url": "https://github.com/canonical/loki-k8s-operator/releases/download/promtail-v2.5.0/promtail-static-amd64.gz",
             }
-        ),
+        }),
     }
     unit_databag = {
-        "endpoint": json.dumps(
-            {
-                "url": "http://loki-k8s-0.loki-k8s-endpoints.model0.svc.cluster.local:3100/loki/api/v1/push"
-            }
-        )
+        "endpoint": json.dumps({
+            "url": "http://loki-k8s-0.loki-k8s-endpoints.model0.svc.cluster.local:3100/loki/api/v1/push"
+        })
     }
     harness.update_relation_data(
         relation_id,

--- a/tox.ini
+++ b/tox.ini
@@ -28,30 +28,29 @@ deps =
     pre-commit
     mypy
     types-PyYAML
+    -r{toxinidir}/fmt-requirements.txt
+    -r{toxinidir}/lint-requirements.txt
 commands =
     pre-commit install -t commit-msg
 
 [testenv:fmt]
-description = Apply coding style standards to code
+description = Apply coding style standards
 deps =
     -r{toxinidir}/fmt-requirements.txt
 commands =
     isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
+    ; The tomli package is needed because https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file
+    tomli
     -r{toxinidir}/lint-requirements.txt
 commands =
-    codespell {[vars]lib_path}
-    codespell {toxinidir}/ --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
+    codespell {toxinidir}/
     isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    ruff check --show-fixes {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This pull request:

- replaces black with ruff as the formatter
- fixes the lint and format issues with ruff
- keeps the isort to keep the original behaviors for import sorting
- puts the codespell configuration to the pyproject.toml file to be consistent with other tools