### PR TITLE
Support local identity provider

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -65,6 +65,8 @@ RELATION_KEYS = [
     "oidc_error_url",
     "device_verification_url",
     "post_device_done_url",
+    "recovery_url",
+    "settings_url",
 ]
 
 
@@ -114,6 +116,8 @@ class LoginUIEndpointsProvider(Object):
                 "oidc_error_url": f"{endpoint}/ui/oidc_error",
                 "device_verification_url": f"{endpoint}/ui/device_code",
                 "post_device_done_url": f"{endpoint}/ui/device_complete",
+                "recovery_url": f"{endpoint}/ui/reset_email",
+                "settings_url": f"{endpoint}/ui/reset_password",
             }
         for relation in relations:
             relation.data[self._charm.app].update(endpoint_databag)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,7 +23,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for login-ui
-    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.14.0
+    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.15.0
 
 requires:
   ingress:

--- a/src/charm.py
+++ b/src/charm.py
@@ -257,6 +257,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                 "PORT": str(APPLICATION_PORT),
                 "BASE_URL": self._domain_url,
                 "TRACING_ENABLED": False,
+                "AUTHORIZATION_ENABLED": False,
                 "LOG_LEVEL": self._log_level,
                 "LOG_FILE": self._log_path,
                 "DEBUG": self._log_level == "DEBUG",


### PR DESCRIPTION
This PR adds changes necessary to support local provider functionalities:
- bumps image to v.0.15.0
- updates the `ui-endpoint-info` lib to include recovery and settings urls