### PR TITLE
chore: bump login ui image to v0.18.4

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,7 +23,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for login-ui
-    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.18.1
+    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.18.4
 
 requires:
   ingress:
@@ -60,6 +60,10 @@ provides:
     description: |
       Forwards the built-in grafana dashboard(s) for monitoring identity-platform-login-ui-operator.
     interface: grafana_dashboard
+
+peers:
+  identity-platform-login-ui:
+    interface: identity_platform_login_ui_peers
 
 config:
   options:

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,3 +6,5 @@
 WORKLOAD_CONTAINER_NAME = "login-ui"
 APPLICATION_PORT = 8080
 CERTIFICATE_TRANSFER_NAME = "receive-ca-cert"
+PEER = "identity-platform-login-ui"
+COOKIES_KEY = "cookies_key"


### PR DESCRIPTION
This PR:
- bumps login ui image to v0.18.4
- adds a new envvar `COOKIES_ENCRYPTION_KEY` to the pebble layer
- adds a peer relation to store the cookie encryption key

### Testing
To test, pack and deploy the charm:
`juju deploy ./*-amd64.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' charmcraft.yaml) --trust`
Once it gets active, ssh into the unit and inspect the pebble plan:
```
$ juju ssh identity-platform-login-ui-operator/0
# PEBBLE_SOCKET=/charm/containers/login-ui/pebble.socket /charm/bin/pebble plan
```
Or simply run `juju show-unit identity-platform-login-ui-operator/0` to see the peer relation data
