### PR TITLE
feat: support oidc webauthn sequencing mode

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,7 +23,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for login-ui
-    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.19.0
+    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.20.0
 
 requires:
   ingress:

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -40,6 +40,7 @@ Class SomeCharm(CharmBase):
 """
 
 import logging
+from os.path import join
 from typing import Dict, Optional
 
 from ops.charm import CharmBase, RelationCreatedEvent
@@ -53,7 +54,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 4
 
 RELATION_NAME = "kratos-info"
 INTERFACE_NAME = "kratos_info"
@@ -91,25 +92,30 @@ class KratosInfoProvider(Object):
         self,
         admin_endpoint: str,
         public_endpoint: str,
+        external_url: str,
         providers_configmap_name: str,
         schemas_configmap_name: str,
         configmaps_namespace: str,
         mfa_enabled: bool,
+        oidc_webauthn_sequencing_enabled: bool,
     ) -> None:
         """Updates relation with endpoints, config and configmaps info."""
         if not self._charm.unit.is_leader():
             return
 
+        external_url = external_url if external_url.endswith("/") else external_url + "/"
+
         relations = self.model.relations[self._relation_name]
         info_databag = {
             "admin_endpoint": admin_endpoint,
             "public_endpoint": public_endpoint,
-            "login_browser_endpoint": f"{public_endpoint}/self-service/login/browser",
+            "login_browser_endpoint": join(external_url, "self-service/login/browser"),
             "sessions_endpoint": f"{public_endpoint}/sessions/whoami",
             "providers_configmap_name": providers_configmap_name,
             "schemas_configmap_name": schemas_configmap_name,
             "configmaps_namespace": configmaps_namespace,
             "mfa_enabled": str(mfa_enabled),
+            "oidc_webauthn_sequencing_enabled": str(oidc_webauthn_sequencing_enabled),
         }
 
         for relation in relations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -275,6 +275,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
 
         if self._kratos_info.is_ready():
             container["environment"]["MFA_ENABLED"] = literal_eval(kratos_info.get("mfa_enabled"))
+            container["environment"]["OIDC_WEBAUTHN_SEQUENCING_ENABLED"] = literal_eval(kratos_info.get("oidc_webauthn_sequencing_enabled"))
 
         if self._tracing_ready:
             container["environment"]["OTEL_HTTP_ENDPOINT"] = self.tracing.get_endpoint("otlp_http")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -50,7 +50,7 @@ async def test_ingress_relation(ops_test: OpsTest):
     await ops_test.model.deploy(
         TRAEFIK,
         application_name=TRAEFIK_PUBLIC_APP,
-        channel="latest/edge",
+        channel="latest/stable",
         config={"external_hostname": "some_hostname"},
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,6 +46,7 @@ def setup_kratos_relation(harness: Harness) -> int:
             "admin_endpoint": f"http://kratos-admin-url:80/{harness.model.name}-kratos",
             "public_endpoint": f"http://kratos-public-url:80/{harness.model.name}-kratos",
             "mfa_enabled": "True",
+            "oidc_webauthn_sequencing_enabled": "False",
         },
     )
     return relation_id
@@ -245,6 +246,14 @@ def test_layer_env_updated_with_kratos_info(harness: Harness) -> None:
             ]
         )
         == harness.get_relation_data(kratos_relation_id, "kratos")["mfa_enabled"]
+    )
+    assert (
+            str(
+                harness.charm._login_ui_layer.to_dict()["services"][CONTAINER_NAME]["environment"][
+                    "OIDC_WEBAUTHN_SEQUENCING_ENABLED"
+                ]
+            )
+            == harness.get_relation_data(kratos_relation_id, "kratos")["oidc_webauthn_sequencing_enabled"]
     )
 
 


### PR DESCRIPTION
This PR adds support for authentication factors sequencing:
- bumps the image to v0.20.0
- adds `OIDC_WEBAUTHN_SEQUENCING_ENABLED` envvar
- updates the `kratos-info` lib to one that includes `oidc_webauthn_sequencing_enabled` in relation data.