### PR TITLE
feat: send webauthn settings url in databag

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -67,6 +67,7 @@ RELATION_KEYS = [
     "post_device_done_url",
     "recovery_url",
     "settings_url",
+    "webauthn_settings_url",
 ]
 
 
@@ -118,6 +119,7 @@ class LoginUIEndpointsProvider(Object):
                 "post_device_done_url": f"{endpoint}/ui/device_complete",
                 "recovery_url": f"{endpoint}/ui/reset_email",
                 "settings_url": f"{endpoint}/ui/reset_password",
+                "webauthn_settings_url": f"{endpoint}/ui/setup_passkey",
             }
         for relation in relations:
             relation.data[self._charm.app].update(endpoint_databag)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -342,6 +342,7 @@ def test_ui_endpoint_info_relation_databag(harness: Harness) -> None:
         "post_device_done_url": f"{url}/ui/device_complete",
         "recovery_url": f"{url}/ui/reset_email",
         "settings_url": f"{url}/ui/reset_password",
+        "webauthn_settings_url": f"{url}/ui/setup_passkey",
     }
 
     relation_data = harness.get_relation_data(relation_id, harness.model.app.name)


### PR DESCRIPTION
- sends the webauthn settings url in databag, so it can be set as the default `return_to` in https://github.com/canonical/kratos-operator/pull/326 instead of redirecting to reset password