### PR TITLE
 ci: use charmcraftcache in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   tests:
     name: CI
-    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@55a44f316b9a0a20057393bf9abf602b2c6ee4bf # IAM-1362-standardize-ci
+    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@v1.6.0
     with:
       charm-name: "identity-platform-login-ui-operator"
       container-name: "login-ui"

--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -13,8 +13,8 @@ jobs:
 
   tests:
     name: CI
-    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@0815f8e87456fd72fdcb68097dae31606ceb01ef # v1.5.0
-#    with:
-#      charm-name: "identity-platform-login-ui-operator"
-#      container-name: "login-ui"
-#      use-charmcraftcache: true
+    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@v1.6.0
+    with:
+      charm-name: "identity-platform-login-ui-operator"
+      container-name: "login-ui"
+      use-charmcraftcache: true

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
-pytest-asyncio==0.25.3
-pytest
+-r requirements.txt
 juju
+pydantic<2.0
+pytest
+pytest-asyncio
 pytest-operator==0.41.0
 requests
-pydantic<2.0
--r requirements.txt

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,7 +33,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     """
     # in GitHub CI, charms are built with charmcraftcache and uploaded to $CHARM_PATH
     charm = os.getenv("CHARM_PATH")
-    logger.info(charm)
     if not charm:
         # fall back to build locally - required when run outside of GitHub CI
         charm = await ops_test.build_charm(".")

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,8 @@ commands =
 
 [testenv:integration]
 description = Run integration tests
+pass_env =
+    CHARM_PATH
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =


### PR DESCRIPTION
- pin the actions to a branch instead of commit
- pass `CHARM_PATH` to tox environment