### PR TITLE
Do not throw error if missing fields

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -155,14 +155,6 @@ class LoginUIEndpointsRelationMissingError(LoginUIEndpointsRelationError):
         super().__init__(self.message)
 
 
-class LoginUIEndpointsRelationDataMissingError(LoginUIEndpointsRelationError):
-    """Raised when information is missing from the relation."""
-
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(self.message)
-
-
 class LoginUIEndpointsRequirer(Object):
     """Requirer side of the ui-endpoint-info relation."""
 
@@ -186,10 +178,5 @@ class LoginUIEndpointsRequirer(Object):
             raise LoginUIEndpointsRelationMissingError()
 
         ui_endpoint_relation_data = ui_endpoint_relation.data[ui_endpoint_relation.app]
-
-        if any(not ui_endpoint_relation_data.get(k := key) for key in RELATION_KEYS):
-            raise LoginUIEndpointsRelationDataMissingError(
-                f"Missing endpoint {k} in ui-endpoint-info relation data"
-            )
 
         return ui_endpoint_relation_data


### PR DESCRIPTION
The lib was validating the fields in the databag, causing any differences in versions between the provider/requirer libs to throw an exception