### PR TITLE
Update login_ui_endpoints lib

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -87,3 +87,6 @@ parts:
     charm-binary-python-packages:
       - jsonschema
       - "setuptools>=70.0.0"
+    build-packages:
+      - rustc
+      - cargo

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 juju
-pydantic<2.0
 pytest
 pytest-asyncio
 pytest-operator==0.41.0

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -37,12 +37,14 @@ Class SomeCharm(CharmBase):
 ```
 """
 
+from typing import List
 import logging
-from typing import Dict
+from typing import Dict, Optional
 
 from ops.charm import CharmBase, RelationCreatedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
-from ops.model import TooManyRelatedAppsError
+from ops import Relation, ModelError
+from pydantic import BaseModel
 
 # The unique Charmhub library identifier, never change it
 LIBID = "f59057701b5840849d3cea756af404c6"
@@ -52,23 +54,24 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
 logger = logging.getLogger(__name__)
 
-RELATION_KEYS = [
-    "consent_url",
-    "error_url",
-    "login_url",
-    "oidc_error_url",
-    "device_verification_url",
-    "post_device_done_url",
-    "recovery_url",
-    "settings_url",
-    "webauthn_settings_url",
-]
+
+class LoginUIProviderData(BaseModel):
+    consent_url: Optional[str] = None
+    error_url: Optional[str] = None
+    login_url: Optional[str] = None
+    oidc_error_url: Optional[str] = None
+    device_verification_url: Optional[str] = None
+    post_device_done_url: Optional[str] = None
+    recovery_url: Optional[str] = None
+    registration_url: Optional[str] = None
+    settings_url: Optional[str] = None
+    webauthn_settings_url: Optional[str] = None
 
 
 class LoginUIEndpointsRelationReadyEvent(EventBase):
@@ -100,29 +103,15 @@ class LoginUIEndpointsProvider(Object):
     def _on_provider_endpoints_relation_created(self, event: RelationCreatedEvent) -> None:
         self.on.ready.emit()
 
-    def send_endpoints_relation_data(self, endpoint: str) -> None:
+    def send_endpoints_relation_data(self, data: LoginUIProviderData) -> None:
         """Updates relation with endpoint info."""
         if not self._charm.unit.is_leader():
-            raise LoginUINonLeaderOperationError()
+            return None
 
         relations = self.model.relations[self._relation_name]
 
-        if not endpoint:
-            endpoint_databag = {k: "" for k in RELATION_KEYS}
-        else:
-            endpoint_databag = {
-                "consent_url": f"{endpoint}/ui/consent",
-                "error_url": f"{endpoint}/ui/error",
-                "login_url": f"{endpoint}/ui/login",
-                "oidc_error_url": f"{endpoint}/ui/oidc_error",
-                "device_verification_url": f"{endpoint}/ui/device_code",
-                "post_device_done_url": f"{endpoint}/ui/device_complete",
-                "recovery_url": f"{endpoint}/ui/reset_email",
-                "settings_url": f"{endpoint}/ui/reset_password",
-                "webauthn_settings_url": f"{endpoint}/ui/setup_passkey",
-            }
         for relation in relations:
-            relation.data[self._charm.app].update(endpoint_databag)
+            relation.data[self._charm.app].update(data.model_dump(exclude_none=True))
 
 
 class LoginUIEndpointsRelationError(Exception):
@@ -131,27 +120,11 @@ class LoginUIEndpointsRelationError(Exception):
     pass
 
 
-class LoginUITooManyRelatedAppsError(LoginUIEndpointsRelationError):
-    """Raised when there are more than one ui-endpoints-info relations between Identity Platform Login UI and another component."""
+class LoginUIEndpointsConflictError(LoginUIEndpointsRelationError):
+    """Raised when we got the same uri multiple times."""
 
     def __init__(self) -> None:
-        self.message = f"Too many applications on {RELATION_NAME}"
-        super().__init__(self.message)
-
-
-class LoginUINonLeaderOperationError(LoginUIEndpointsRelationError):
-    """Raised when a non-leader unit wants to call a function intended for leader units."""
-
-    def __init__(self) -> None:
-        self.message = "Calling Identity Platform Login UI unit is not leader"
-        super().__init__(self.message)
-
-
-class LoginUIEndpointsRelationMissingError(LoginUIEndpointsRelationError):
-    """Raised when the relation is missing."""
-
-    def __init__(self) -> None:
-        self.message = "Missing ui-endpoint-info relation with Identity Platform Login UI"
+        self.message = "Got the same uri from multiple relations"
         super().__init__(self.message)
 
 
@@ -163,20 +136,35 @@ class LoginUIEndpointsRequirer(Object):
         self.charm = charm
         self._relation_name = relation_name
 
-    def get_login_ui_endpoints(self, relation_id=None) -> Dict:
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return [
+            relation
+            for relation in self.charm.model.relations[self._relation_name]
+            if relation.active
+        ]
+
+    def _get_login_ui_endpoints_data(self, relation: Relation) -> Optional[Dict]:
+        return relation.data[relation.app] if relation.app else None
+
+    def get_login_ui_endpoints(self, relation_id=None) -> Optional[Dict]:
         """Get the Identity Platform Login UI endpoints."""
+        if relation_id:
+            relations = [self.model.get_relation(self._relation_name, relation_id=relation_id)]
+        else:
+            relations = self.relations
 
-        try:
-            ui_endpoint_relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
-        except TooManyRelatedAppsError:
-            raise LoginUITooManyRelatedAppsError()
+        if not relations:
+            return None
 
-        if ui_endpoint_relation is None:
-            raise LoginUIEndpointsRelationMissingError()
+        data = {}
+        for r in relations:
+            d = self._get_login_ui_endpoints_data(r)
+            if not d:
+                continue
+            if set(d.keys()).intersection(data.keys()):
+                raise LoginUIEndpointsConflictError()
+            data.update(d)
 
-        if not ui_endpoint_relation.app:
-            raise LoginUIEndpointsRelationMissingError()
-
-        ui_endpoint_relation_data = ui_endpoint_relation.data[ui_endpoint_relation.app]
-
-        return ui_endpoint_relation_data
+        return data

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""# Interface Library for ingress.
@@ -13,7 +13,7 @@ To get started using the library, you just need to fetch the library using `char
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.traefik_k8s.v1.ingress
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
 ```
 
 In the `metadata.yaml` of the charm, add the following:
@@ -50,26 +50,31 @@ class SomeCharm(CharmBase):
     def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
         logger.info("This app no longer has ingress")
 """
+import ipaddress
 import json
 import logging
 import socket
 import typing
 from dataclasses import dataclass
+from functools import partial
 from typing import (
     Any,
+    Callable,
     Dict,
     List,
     MutableMapping,
     Optional,
     Sequence,
     Tuple,
+    Union,
+    cast,
 )
 
 import pydantic
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
 from ops.framework import EventSource, Object, ObjectEvents, StoredState
 from ops.model import ModelError, Relation, Unit
-from pydantic import AnyHttpUrl, BaseModel, Field, validator
+from pydantic import AnyHttpUrl, BaseModel, Field
 
 # The unique Charmhub library identifier, never change it
 LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
@@ -79,9 +84,9 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 15
 
-PYDEPS = ["pydantic<2.0"]
+PYDEPS = ["pydantic"]
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -89,51 +94,137 @@ RELATION_INTERFACE = "ingress"
 log = logging.getLogger(__name__)
 BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
 
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:
+    from pydantic import validator
 
-class DatabagModel(BaseModel):
-    """Base databag model."""
+    input_validator = partial(validator, pre=True)
 
-    class Config:
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")
+
+    class DatabagModel(BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
         """Pydantic config."""
 
-        allow_population_by_field_name = True
-        """Allow instantiating this class by field name (instead of forcing alias)."""
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
 
-    _NEST_UNDER = None
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
 
-    @classmethod
-    def load(cls, databag: MutableMapping):
-        """Load this model from a Juju databag."""
-        if cls._NEST_UNDER:
-            return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
 
-        try:
-            data = {k: json.loads(v) for k, v in databag.items() if k not in BUILTIN_JUJU_KEYS}
-        except json.JSONDecodeError:
-            log.error(f"invalid databag contents: expecting json. {databag}")
-            raise
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
 
-        try:
-            return cls.parse_raw(json.dumps(data))  # type: ignore
-        except pydantic.ValidationError as e:
-            msg = f"failed to validate databag: {databag}"
-            log.error(msg, exc_info=True)
-            raise DataValidationError(msg) from e
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
 
-    def dump(self, databag: Optional[MutableMapping] = None):
-        """Write the contents of this model to Juju databag."""
-        if databag is None:
-            databag = {}
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
 
-        if self._NEST_UNDER:
-            databag[self._NEST_UNDER] = self.json()
-
-        dct = self.dict()
-        for key, field in self.__fields__.items():  # type: ignore
-            value = dct[key]
-            databag[field.alias or key] = json.dumps(value)
-
-        return databag
+            dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)  # type: ignore
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
 
 
 # todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
@@ -146,7 +237,7 @@ class IngressUrl(BaseModel):
 class IngressProviderAppData(DatabagModel):
     """Ingress application databag schema."""
 
-    ingress: IngressUrl
+    ingress: Optional[IngressUrl] = None
 
 
 class ProviderSchema(BaseModel):
@@ -155,33 +246,57 @@ class ProviderSchema(BaseModel):
     app: IngressProviderAppData
 
 
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
 class IngressRequirerAppData(DatabagModel):
     """Ingress requirer application databag model."""
 
     model: str = Field(description="The model the application is in.")
     name: str = Field(description="the name of the app requesting ingress.")
     port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
 
     # fields on top of vanilla 'ingress' interface:
     strip_prefix: Optional[bool] = Field(
-        description="Whether to strip the prefix from the ingress url.", alias="strip-prefix"
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
     )
     redirect_https: Optional[bool] = Field(
-        description="Whether to redirect http traffic to https.", alias="redirect-https"
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
     )
 
     scheme: Optional[str] = Field(
         default="http", description="What scheme to use in the generated ingress url"
     )
 
-    @validator("scheme", pre=True)
+    @input_validator("scheme")
     def validate_scheme(cls, scheme):  # noqa: N805  # pydantic wants 'cls' as first arg
         """Validate scheme arg."""
         if scheme not in {"http", "https", "h2c"}:
             raise ValueError("invalid scheme: should be one of `http|https|h2c`")
         return scheme
 
-    @validator("port", pre=True)
+    @input_validator("port")
     def validate_port(cls, port):  # noqa: N805  # pydantic wants 'cls' as first arg
         """Validate port."""
         assert isinstance(port, int), type(port)
@@ -192,13 +307,36 @@ class IngressRequirerAppData(DatabagModel):
 class IngressRequirerUnitData(DatabagModel):
     """Ingress requirer unit databag model."""
 
-    host: str = Field(description="Hostname the unit wishes to be exposed.")
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
 
-    @validator("host", pre=True)
+    @input_validator("host")
     def validate_host(cls, host):  # noqa: N805  # pydantic wants 'cls' as first arg
         """Validate host."""
         assert isinstance(host, str), type(host)
         return host
+
+    @input_validator("ip")
+    def validate_ip(cls, ip):  # noqa: N805  # pydantic wants 'cls' as first arg
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
 
 
 class RequirerSchema(BaseModel):
@@ -236,6 +374,7 @@ class _IngressPerAppBase(Object):
         observe(rel_events.relation_created, self._handle_relation)
         observe(rel_events.relation_joined, self._handle_relation)
         observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
         observe(rel_events.relation_broken, self._handle_relation_broken)
         observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
         observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
@@ -332,14 +471,6 @@ class IngressRequirerData:
     units: List["IngressRequirerUnitData"]
 
 
-class TlsProviderType(typing.Protocol):
-    """Placeholder."""
-
-    @property
-    def enabled(self) -> bool:  # type: ignore
-        """Placeholder."""
-
-
 class IngressPerAppProvider(_IngressPerAppBase):
     """Implementation of the provider of ingress."""
 
@@ -368,7 +499,10 @@ class IngressPerAppProvider(_IngressPerAppBase):
                 event.relation,
                 data.app.name,
                 data.app.model,
-                [unit.dict() for unit in data.units],
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
                 data.app.strip_prefix or False,
                 data.app.redirect_https or False,
             )
@@ -421,7 +555,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             return IngressRequirerData(
                 self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
             )
-        except (pydantic.ValidationError, DataValidationError, json.JSONDecodeError) as e:
+        except (pydantic.ValidationError, DataValidationError) as e:
             raise DataValidationError("failed to validate ingress requirer data") from e
 
     def is_ready(self, relation: Optional[Relation] = None):
@@ -455,10 +589,19 @@ class IngressPerAppProvider(_IngressPerAppBase):
     def publish_url(self, relation: Relation, url: str):
         """Publish to the app databag the ingress url."""
         ingress_url = {"url": url}
-        IngressProviderAppData.parse_obj({"ingress": ingress_url}).dump(relation.data[self.app])
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                "url was not published to ingress relation for {relation.app}.  This error is likely due to an"
+                " error or misconfiguration of the charm calling this library."
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
 
     @property
-    def proxied_endpoints(self) -> Dict[str, str]:
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
         """Returns the ingress settings provided to applications by this IngressPerAppProvider.
 
         For example, when this IngressPerAppProvider has provided the
@@ -473,7 +616,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         }
         ```
         """
-        results = {}
+        results: Dict[str, Dict[str, str]] = {}
 
         for ingress_relation in self.relations:
             if not ingress_relation.app:
@@ -494,7 +637,13 @@ class IngressPerAppProvider(_IngressPerAppBase):
                 log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
                 continue
 
-            results[ingress_relation.app.name] = ingress_data.ingress.dict()
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = ingress_data.ingress
+            ingress = cast(IngressProviderAppData, ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
         return results
 
 
@@ -532,12 +681,14 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         relation_name: str = DEFAULT_RELATION_NAME,
         *,
         host: Optional[str] = None,
+        ip: Optional[str] = None,
         port: Optional[int] = None,
         strip_prefix: bool = False,
         redirect_https: bool = False,
         # fixme: this is horrible UX.
         #  shall we switch to manually calling provide_ingress_requirements with all args when ready?
-        scheme: typing.Callable[[], str] = lambda: "http",
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
     ):
         """Constructor for IngressRequirer.
 
@@ -547,38 +698,51 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         All request args must be given as keyword args.
 
         Args:
-            charm: the charm that is instantiating the library.
-            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
-                relation must be of interface type `ingress` and have "limit: 1")
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
             host: Hostname to be used by the ingress provider to address the requiring
                 application; if unspecified, the default Kubernetes service name will be used.
-            strip_prefix: configure Traefik to strip the path prefix.
-            redirect_https: redirect incoming requests to HTTPS.
-            scheme: callable returning the scheme to use when constructing the ingress url.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema. The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check endpoint.
+                    - "interval" (str): Frequency of the health check calls (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress URL,
+                or a string if the scheme is known and stable at charm initialization.
 
         Request Args:
             port: the port of the service
         """
         super().__init__(charm, relation_name)
         self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
         self.relation_name = relation_name
         self._strip_prefix = strip_prefix
         self._redirect_https = redirect_https
-        self._get_scheme = scheme
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
 
         self._stored.set_default(current_url=None)  # type: ignore
 
         # if instantiated with a port, and we are related, then
         # we immediately publish our ingress data  to speed up the process.
         if port:
-            self._auto_data = host, port
+            self._auto_data = host, ip, port
         else:
             self._auto_data = None
 
     def _handle_relation(self, event):
         # created, joined or changed: if we have auto data: publish it
-        self._publish_auto_data(event.relation)
-
+        self._publish_auto_data()
         if self.is_ready():
             # Avoid spurious events, emit only when there is a NEW URL available
             new_url = (
@@ -596,8 +760,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
     def _handle_upgrade_or_leader(self, event):
         """On upgrade/leadership change: ensure we publish the data we have."""
-        for relation in self.relations:
-            self._publish_auto_data(relation)
+        self._publish_auto_data()
 
     def is_ready(self):
         """The Requirer is ready if the Provider has sent valid data."""
@@ -607,13 +770,18 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             log.debug("Requirer not ready; validation error encountered: %s" % str(e))
             return False
 
-    def _publish_auto_data(self, relation: Relation):
+    def _publish_auto_data(self):
         if self._auto_data:
-            host, port = self._auto_data
-            self.provide_ingress_requirements(host=host, port=port)
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
 
     def provide_ingress_requirements(
-        self, *, scheme: Optional[str] = None, host: Optional[str] = None, port: int
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
     ):
         """Publishes the data that Traefik needs to provide ingress.
 
@@ -621,46 +789,82 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             scheme: Scheme to be used; if unspecified, use the one used by __init__.
             host: Hostname to be used by the ingress provider to address the
              requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
             port: the port of the service (required)
         """
-        # This public method may be used at various points of the charm lifecycle, possible when
-        # the ingress relation is not yet there.
-        # Abort if there is no relation (instead of requiring the caller to guard against it).
-        if not self.relation:
-            return
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
 
-        # get only the leader to publish the data since we only
-        # require one unit to publish it -- it will not differ between units,
-        # unlike in ingress-per-unit.
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
         if self.unit.is_leader():
-            app_databag = self.relation.data[self.app]
+            self._publish_app_data(scheme, port, relation)
 
-            if not scheme:
-                # If scheme was not provided, use the one given to the constructor.
-                scheme = self._get_scheme()
+        self._publish_unit_data(host, ip, relation)
 
-            try:
-                IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
-                    model=self.model.name,
-                    name=self.app.name,
-                    scheme=scheme,
-                    port=port,
-                    strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
-                    redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
-                ).dump(app_databag)
-            except pydantic.ValidationError as e:
-                msg = "failed to validate app data"
-                log.info(msg, exc_info=True)  # log to INFO because this might be expected
-                raise DataValidationError(msg) from e
-
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ):
         if not host:
             host = socket.getfqdn()
 
-        unit_databag = self.relation.data[self.unit]
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
         try:
-            IngressRequirerUnitData(host=host).dump(unit_databag)
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
         except pydantic.ValidationError as e:
             msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ):
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
+                redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
             log.info(msg, exc_info=True)  # log to INFO because this might be expected
             raise DataValidationError(msg) from e
 
@@ -691,7 +895,11 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         if not databag:  # not ready yet
             return None
 
-        return str(IngressProviderAppData.load(databag).ingress.url)
+        ingress = IngressProviderAppData.load(databag).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
 
     @property
     def url(self) -> Optional[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ops>=2.0.0
 lightkube
 lightkube-models
 jsonschema
+pydantic~=2.10.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,7 @@ def harness(mocked_kubernetes_service_patcher: MagicMock) -> ops.testing.Harness
     harness = ops.testing.Harness(IdentityPlatformLoginUiOperatorCharm)
     harness.set_model_name("testing")
     harness.begin()
+    harness.add_network("10.0.0.10")
     return harness
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,6 +8,7 @@
 import json
 from typing import Tuple
 
+from charms.identity_platform_login_ui_operator.v0.login_ui_endpoints import LoginUIProviderData
 from ops.model import ActiveStatus, WaitingStatus
 from ops.testing import Harness
 from pytest_mock import MockerFixture
@@ -324,7 +325,20 @@ def test_ui_endpoint_info(harness: Harness, mocker: MockerFixture) -> None:
     relation_id = harness.add_relation("ui-endpoint-info", "hydra")
     harness.add_relation_unit(relation_id, "hydra/0")
 
-    mocked_service_patcher.assert_called_with(url.replace("http", "https").replace(":80", ""))
+    url = url.replace("http", "https").replace(":80", "")
+    mocked_service_patcher.assert_called_with(
+        LoginUIProviderData(
+            consent_url=f"{url}/ui/consent",
+            error_url=f"{url}/ui/error",
+            login_url=f"{url}/ui/login",
+            oidc_error_url=f"{url}/ui/oidc_error",
+            device_verification_url=f"{url}/ui/device_code",
+            post_device_done_url=f"{url}/ui/device_complete",
+            recovery_url=f"{url}/ui/reset_email",
+            settings_url=f"{url}/ui/reset_password",
+            webauthn_settings_url=f"{url}/ui/setup_passkey",
+        )
+    )
 
 
 def test_ui_endpoint_info_relation_databag(harness: Harness) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -248,12 +248,14 @@ def test_layer_env_updated_with_kratos_info(harness: Harness) -> None:
         == harness.get_relation_data(kratos_relation_id, "kratos")["mfa_enabled"]
     )
     assert (
-            str(
-                harness.charm._login_ui_layer.to_dict()["services"][CONTAINER_NAME]["environment"][
-                    "OIDC_WEBAUTHN_SEQUENCING_ENABLED"
-                ]
-            )
-            == harness.get_relation_data(kratos_relation_id, "kratos")["oidc_webauthn_sequencing_enabled"]
+        str(
+            harness.charm._login_ui_layer.to_dict()["services"][CONTAINER_NAME]["environment"][
+                "OIDC_WEBAUTHN_SEQUENCING_ENABLED"
+            ]
+        )
+        == harness.get_relation_data(kratos_relation_id, "kratos")[
+            "oidc_webauthn_sequencing_enabled"
+        ]
     )
 
 

--- a/unit-requirements.txt
+++ b/unit-requirements.txt
@@ -2,5 +2,4 @@ pytest
 pytest-mock
 coverage[toml]
 requests
-pydantic<2.0
 -r requirements.txt


### PR DESCRIPTION
IAM-1418

- Update pydantic to v2
- Update the login_ui_endpoints lib to support fetching the endpoints from multiple charms
- Refactor the login_ui_endpoints lib to use pydantic and get rid of all of these ugly exceptions
- Bump ingress lib version

The plan is that kratos will be fetching the ui endpoints from multiple charms. This is needed for the registration webhook service, because the user-verification charm will need to provide the registration_uri to kratos.

This will be tested as a whole in the user-verification-service-operator.