### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,14 +58,17 @@ provides:
     interface: login_ui_endpoints
     description: |
       Provides the Identity Platform Login UI API endpoints to a related application
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
     description: |
       Provides application metrics to COS Prometheus instance
+    optional: true
   grafana-dashboard:
     description: |
       Forwards the built-in grafana dashboard(s) for monitoring identity-platform-login-ui-operator.
     interface: grafana_dashboard
+    optional: true
 
 peers:
   identity-platform-login-ui:


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
