### PR TITLE
Add account linking page to login ui endpoints lib

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,7 +20,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for login-ui
-    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.21.3
+    upstream-source: ghcr.io/canonical/identity-platform-login-ui:v0.23.0
 requires:
   ingress:
     interface: ingress

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -54,7 +54,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -72,6 +72,7 @@ class LoginUIProviderData(BaseModel):
     registration_url: Optional[str] = None
     settings_url: Optional[str] = None
     webauthn_settings_url: Optional[str] = None
+    account_linking_settings_url: Optional[str] = None
 
 
 class LoginUIEndpointsRelationReadyEvent(EventBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -278,6 +278,7 @@ class IdentityPlatformLoginUiOperatorCharm(CharmBase):
                 recovery_url=f"{endpoint}/ui/reset_email",
                 settings_url=f"{endpoint}/ui/reset_password",
                 webauthn_settings_url=f"{endpoint}/ui/setup_passkey",
+                account_linking_settings_url=f"{endpoint}/ui/manage_connected_accounts",
             )
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -340,6 +340,7 @@ def test_ui_endpoint_info(harness: Harness, mocker: MockerFixture) -> None:
             recovery_url=f"{url}/ui/reset_email",
             settings_url=f"{url}/ui/reset_password",
             webauthn_settings_url=f"{url}/ui/setup_passkey",
+            account_linking_settings_url=f"{url}/ui/manage_connected_accounts",
         )
     )
 
@@ -362,6 +363,7 @@ def test_ui_endpoint_info_relation_databag(harness: Harness) -> None:
         "recovery_url": f"{url}/ui/reset_email",
         "settings_url": f"{url}/ui/reset_password",
         "webauthn_settings_url": f"{url}/ui/setup_passkey",
+        "account_linking_settings_url": f"{url}/ui/manage_connected_accounts",
     }
 
     relation_data = harness.get_relation_data(relation_id, harness.model.app.name)


### PR DESCRIPTION
- Add `account_linking_settings_url` to the library so that we can use it in kratos config
- Bump image to v0.23.0