### PR TITLE
fix: enable the charm resources in terraform module

### DIFF
--- a/terraform/MODULE_SPECS.md
+++ b/terraform/MODULE_SPECS.md
@@ -29,6 +29,7 @@ identity-platform-login-ui charm using the Juju Terraform provider.
 | <a name="input_base"></a> [base](#input\_base) | The charm base | `string` | `"ubuntu@22.04"` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | The charm channel | `string` | `"latest/stable"` | no |
 | <a name="input_revision"></a> [revision](#input\_revision) | The charm revision | `number` | `null` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | The charm resources | `map(string)` | `{}` | no |
 ---
 ## Outputs
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,12 +5,21 @@
  * identity-platform-login-ui charm using the Juju Terraform provider.
  */
 
+locals {
+  charmcraft = yamldecode(file("${path.module}/../charmcraft.yaml"))
+  oci_image = {
+    "oci-image" : local.charmcraft.resources.oci-image.upstream-source
+  }
+  resources = merge(local.oci_image, var.resources)
+}
+
 resource "juju_application" "application" {
   name        = var.app_name
   model       = var.model_name
   trust       = true
   config      = var.config
   constraints = var.constraints
+  resources   = local.resources
   units       = var.units
 
   charm {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,3 +47,9 @@ variable "revision" {
   nullable    = true
   default     = null
 }
+
+variable "resources" {
+  description = "The charm resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This pull request aims to resolve the https://github.com/canonical/identity-team/issues/66.