### PR TITLE
Add `FEATURE_FLAGS` env var to service definition environment

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -4,6 +4,7 @@
 import json
 import logging
 from dataclasses import dataclass, field
+from typing import Optional
 from urllib.parse import urlparse
 
 from charms.hydra.v0.hydra_endpoints import (
@@ -54,6 +55,7 @@ class KratosInfoData:
     mfa_enabled: bool = False
     oidc_webauthn_sequencing_enabled: bool = False
     is_ready: bool = False
+    feature_flags: Optional[list[str]] = None
 
     @classmethod
     def load(cls, requirer: KratosInfoRequirer) -> "KratosInfoData":
@@ -72,6 +74,7 @@ class KratosInfoData:
             mfa_enabled=info.get("mfa_enabled"),
             oidc_webauthn_sequencing_enabled=info.get("oidc_webauthn_sequencing_enabled"),
             is_ready=requirer.is_ready(),
+            feature_flags=info.get("feature_flags", None),
         )
 
 

--- a/src/services.py
+++ b/src/services.py
@@ -95,6 +95,9 @@ class PebbleService:
             },
         }
 
+        if kratos_info.feature_flags:
+            container["environment"]["FEATURE_FLAGS"] = kratos_info.feature_flags
+
         if kratos_info.is_ready:
             container["environment"]["MFA_ENABLED"] = kratos_info.mfa_enabled
             container["environment"]["OIDC_WEBAUTHN_SEQUENCING_ENABLED"] = (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -55,6 +55,7 @@ def setup_kratos_relation(harness: Harness) -> int:
             "public_endpoint": f"http://kratos-public-url:80/{harness.model.name}-kratos",
             "mfa_enabled": "True",
             "oidc_webauthn_sequencing_enabled": "False",
+            "feature_flags": "password,totp,webauthn,backup_codes,account_linking",
         },
     )
     return relation_id
@@ -265,6 +266,13 @@ def test_layer_env_updated_with_kratos_info(harness: Harness) -> None:
         == harness.get_relation_data(kratos_relation_id, "kratos")[
             "oidc_webauthn_sequencing_enabled"
         ]
+    )
+
+    assert (
+        harness.charm._login_ui_layer.to_dict()["services"][CONTAINER_NAME]["environment"][
+            "FEATURE_FLAGS"
+        ]
+        == harness.get_relation_data(kratos_relation_id, "kratos")["feature_flags"]
     )
 
 


### PR DESCRIPTION
## Description
Reads active feature flags from the Kratos Info databag and sets the corresponding environment variable in the service definition.
