### PR TITLE
chore: use tox devenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,13 @@ enhancements to this operator.
 
 ## Developing
 
-You can use the environments created by `tox` for development. It helps
-install `pre-commit`, `mypy` type checker, linting tools, and formatting tools.
+You can use the environments created by `tox` for development. It helps install
+`pre-commit`, `mypy` type checker, linting and formatting tools, as well as unit
+and integration test dependencies.
 
 ```shell
-tox -e dev
-source .tox/dev/bin/activate
+tox devenv
+source venv/bin/activate
 ```
 
 ## Testing

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ passenv =
   CHARM_BUILD_DIR
   MODEL_SETTINGS
 
-[testenv:dev]
+[testenv:py]
 description = Prepare local development tools
 deps =
     pre-commit
@@ -30,6 +30,8 @@ deps =
     types-PyYAML
     -r{toxinidir}/fmt-requirements.txt
     -r{toxinidir}/lint-requirements.txt
+    -r{toxinidir}/unit-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
 commands =
     pre-commit install -t commit-msg
 


### PR DESCRIPTION
This is a newer feature that tox uses specifically for creating dev environments (instead of the old method of using -e).