### PR TITLE
fix: Adjust terraform module to remove resource passing

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,8 +18,8 @@ resource "juju_application" "application" {
   trust       = true
   config      = var.config
   constraints = var.constraints
-  resources   = local.resources
-  units       = var.units
+  # resources   = local.resources
+  units = var.units
 
   charm {
     name     = "identity-platform-login-ui-operator"


### PR DESCRIPTION
During deployment JIMM fails to authenticate potentially due to the upload of the OCI image

<img width="954" height="767" alt="image" src="https://github.com/user-attachments/assets/a9848d0b-779c-4278-b111-0129c9c04aeb" />


dropping it for now and opening a bug 
