### PR TITLE
Add verification enabled flag

### DIFF
--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -54,7 +54,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 6
 
 RELATION_NAME = "kratos-info"
 INTERFACE_NAME = "kratos_info"
@@ -98,6 +98,8 @@ class KratosInfoProvider(Object):
         configmaps_namespace: str,
         mfa_enabled: bool,
         oidc_webauthn_sequencing_enabled: bool,
+        verification_enabled: bool,
+        feature_flags: Optional[list[str]] = None,
     ) -> None:
         """Updates relation with endpoints, config and configmaps info."""
         if not self._charm.unit.is_leader():
@@ -116,7 +118,11 @@ class KratosInfoProvider(Object):
             "configmaps_namespace": configmaps_namespace,
             "mfa_enabled": str(mfa_enabled),
             "oidc_webauthn_sequencing_enabled": str(oidc_webauthn_sequencing_enabled),
+            "verification_enabled": str(verification_enabled),
         }
+
+        if feature_flags:
+            info_databag["feature_flags"] = ",".join(feature_flags)
 
         for relation in relations:
             relation.data[self._charm.app].update(info_databag)

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -54,6 +54,7 @@ class KratosInfoData:
     admin_endpoint: str = ""
     mfa_enabled: bool = False
     oidc_webauthn_sequencing_enabled: bool = False
+    verification_enabled: bool = False
     is_ready: bool = False
     feature_flags: Optional[list[str]] = None
 
@@ -73,6 +74,7 @@ class KratosInfoData:
             admin_endpoint=info.get("admin_endpoint"),
             mfa_enabled=info.get("mfa_enabled"),
             oidc_webauthn_sequencing_enabled=info.get("oidc_webauthn_sequencing_enabled"),
+            verification_enabled=info.get("verification_enabled"),
             is_ready=requirer.is_ready(),
             feature_flags=info.get("feature_flags", None),
         )

--- a/src/services.py
+++ b/src/services.py
@@ -103,6 +103,7 @@ class PebbleService:
             container["environment"]["OIDC_WEBAUTHN_SEQUENCING_ENABLED"] = (
                 kratos_info.oidc_webauthn_sequencing_enabled
             )
+            container["environment"]["VERIFICATION_ENABLED"] = kratos_info.verification_enabled
 
         if tracing_data.is_ready:
             container["environment"]["OTEL_HTTP_ENDPOINT"] = tracing_data.http_endpoint

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -121,6 +121,7 @@ def kratos_relation() -> ops.testing.Relation:
             "public_endpoint": "http://kratos-public-url:80/testing-kratos",
             "mfa_enabled": "True",
             "oidc_webauthn_sequencing_enabled": "False",
+            "verification_enabled": "True",
             "feature_flags": "password,totp,webauthn,backup_codes,account_linking",
         },
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -125,6 +125,7 @@ class TestKratosRelationEvents:
         assert env["KRATOS_PUBLIC_URL"] == kratos_data["public_endpoint"]
         assert env["KRATOS_ADMIN_URL"] == kratos_data["admin_endpoint"]
         assert str(env["MFA_ENABLED"]) == kratos_data["mfa_enabled"]
+        assert str(env["VERIFICATION_ENABLED"]) == kratos_data["verification_enabled"]
         assert (
             str(env["OIDC_WEBAUTHN_SEQUENCING_ENABLED"])
             == kratos_data["oidc_webauthn_sequencing_enabled"]


### PR DESCRIPTION
This PR
- bumps the `kratos-info` lib version
- adds `verification_enabled` flag to the workload