### PR TITLE
feat: multi-base support

### DIFF
--- a/.github/workflows/auto-approver.yaml
+++ b/.github/workflows/auto-approver.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   auto-approve:
     name: Auto-approve and merge pull request
-    uses: canonical/identity-team/.github/workflows/pr-auto-approval.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/pr-auto-approval.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   tests:
     name: CI
-    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       container-name: "login-ui"
       use-charmcraftcache: false

--- a/.github/workflows/cves.yaml
+++ b/.github/workflows/cves.yaml
@@ -29,10 +29,10 @@ jobs:
                 issue: ${{ fromJson(needs.list-all-issues.outputs.issues) }}
         needs: 
             - list-all-issues                    
-        uses: canonical/identity-team/.github/workflows/cve-check.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+        uses: canonical/identity-team/.github/workflows/cve-check.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
         with: 
             issue: ${{ matrix.issue }}
 
     apply-labels:
-        uses: canonical/identity-team/.github/workflows/cve-check.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+        uses: canonical/identity-team/.github/workflows/cve-check.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
         if: ${{ github.event.issue.id }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   deploy:
     name: Deploy Charm to ${{ inputs.model }}
-    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       model: ${{ inputs.model }}
       revision: ${{ inputs.revision }}

--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -16,4 +16,4 @@ jobs:
     uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       container-name: "login-ui"
-      use-charmcraftcache: true
+      use-charmcraftcache: false

--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -6,14 +6,14 @@ on:
 jobs:
   update-charm-libs:
     name: Update Charm Libraries
-    uses: canonical/identity-team/.github/workflows/charm-libs-update.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-libs-update.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   tests:
     name: CI
-    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       container-name: "login-ui"
       use-charmcraftcache: true

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   promote-charm:
       name: Promote charm
-      uses: canonical/identity-team/.github/workflows/charm-promotion.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+      uses: canonical/identity-team/.github/workflows/charm-promotion.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
       with:
         origin-channel: ${{ github.event.inputs.origin-channel }}
         destination-channel: ${{ github.event.inputs.destination-channel }}
@@ -65,7 +65,7 @@ jobs:
       - promote-charm
       - revision
     if: ${{ (github.event.inputs.destination-channel == 'latest/edge') }}
-    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       CLIENT_ID: ${{ secrets.JIMM_DEV_CLIENT_ID }}
       CLIENT_SECRET: ${{ secrets.JIMM_DEV_CLIENT_SECRET }}
@@ -85,7 +85,7 @@ jobs:
       - promote-charm
       - revision
     if: ${{ (github.event.inputs.destination-channel == 'latest/stable') }}
-    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       CLIENT_ID: ${{ secrets.JIMM_STG_CLIENT_ID }}
       CLIENT_SECRET: ${{ secrets.JIMM_STG_CLIENT_SECRET }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,7 @@ jobs:
     with:
       destination_channel: ${{ inputs.destination_channel}}
       source_branch: ${{ inputs.source_branch}}
-      use-charmcraftcache: true
+      use-charmcraftcache: false
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS}}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       issues: write
     name: Publish Charm
-    uses: canonical/identity-team/.github/workflows/charm-publish.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-publish.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       destination_channel: ${{ inputs.destination_channel}}
       source_branch: ${{ inputs.source_branch}}
@@ -76,7 +76,7 @@ jobs:
       - publish
       - revision
     if: ${{ (needs.publish.outputs.channel == 'latest/edge') }}
-    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
         model: blue-iam
         revision: ${{ needs.revision.outputs.revision }}
@@ -97,7 +97,7 @@ jobs:
       - publish
       - revision
     if: ${{ (needs.publish.outputs.channel == 'latest/stable') }}
-    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-deploy.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       model: green-iam
       revision: ${{ needs.revision.outputs.revision }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   release:
       name: release
-      uses: canonical/identity-team/.github/workflows/charm-release.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+      uses: canonical/identity-team/.github/workflows/charm-release.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
       secrets:
         PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/release_libs.yaml
+++ b/.github/workflows/release_libs.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Release any bumped library
     needs: filter
     if: needs.filter.outputs.run-release == 'true'
-    uses: canonical/identity-team/.github/workflows/charm-libs-release.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-libs-release.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/update_libs.yaml
+++ b/.github/workflows/update_libs.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-charm-libs:
     name: Update Charm Libraries
-    uses: canonical/identity-team/.github/workflows/charm-libs-update.yaml@b5070d98993fa72f429f4fdf8010f6f9a94eb4e0 # v1.14.2
+    uses: canonical/identity-team/.github/workflows/charm-libs-update.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -102,6 +102,8 @@ config:
 platforms:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
 parts:
   templates:
     plugin: dump

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -115,6 +115,3 @@ parts:
     source: .
     build-snaps:
       - astral-uv
-    build-packages:
-      - "rustc-1.85"
-      - "cargo-1.85"


### PR DESCRIPTION
- adds support for 26.04 base
- disable charmcraftcache in all workflows
- remove rustc and cargo dependencies from `charmcraft.yaml` since they are no longer required with uv